### PR TITLE
Expose XStream object in DefaultXmlSerializer

### DIFF
--- a/src/java/com/strategicgains/restexpress/serialization/xml/DefaultXmlProcessor.java
+++ b/src/java/com/strategicgains/restexpress/serialization/xml/DefaultXmlProcessor.java
@@ -58,6 +58,11 @@ implements AliasingSerializationProcessor
 		shouldAutoAlias = false;
 	}
 	
+	protected XStream getXStream()
+	{
+		return this.xstream;
+	}
+	
 	
 	// SECTION: XML NAME ALIASING
 


### PR DESCRIPTION
Rather than adding methods for all the crazy things you can do with XStream, I figured it would just be easier to expose the XStream object on DefaultXmlSerializer.
