### PR TITLE
Exposed Channelpipeline

### DIFF
--- a/src/java/com/strategicgains/restexpress/RestExpress.java
+++ b/src/java/com/strategicgains/restexpress/RestExpress.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.group.ChannelGroupFuture;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
@@ -888,4 +889,9 @@ public class RestExpress
 	{
 		return routeDeclarations.regex(uriPattern, controller, routeDefaults);
 	}
+
+    public ChannelPipeline getPipeline() {
+
+        return bootstrap.getPipeline();
+    }
 }


### PR DESCRIPTION
In order to plug in new Handlers to the Channelpipeline I exposed Nettys Channelpipeline via a getter in the RestExpress class. This enables Plugins to hook in new Handlers (like SSL Handlers, etc)
