### PR TITLE
Expose the DefaultRequestHandler to rest engines not using your "main" or "bind".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .project
 .classpath
 .settings
+*.swp

--- a/src/java/com/strategicgains/restexpress/RestExpress.java
+++ b/src/java/com/strategicgains/restexpress/RestExpress.java
@@ -622,6 +622,29 @@ public class RestExpress
 		return bind((getPort() > 0 ? getPort() : DEFAULT_PORT));
 	}
 
+    /**
+     * Build a default request handler so it may be used injected into any existing pipeline.
+     *
+     * @return DefaultRequestHandler
+     */
+    public DefaultRequestHandler buildRequestHandler() {
+		// Set up the event pipeline factory.
+		DefaultRequestHandler requestHandler = new DefaultRequestHandler(
+		    createRouteResolver(), createResponseProcessorResolver());
+
+		// Add MessageObservers to the request handler here, if desired...
+		requestHandler.addMessageObserver(messageObservers.toArray(new MessageObserver[0]));
+
+		requestHandler.setExceptionMap(exceptionMap);
+
+		// Add pre/post processors to the request handler here...
+		addPreprocessors(requestHandler);
+		addPostprocessors(requestHandler);
+		addFinallyProcessors(requestHandler);
+
+        return requestHandler;
+    }
+
 	/**
 	 * The last call in the building of a RestExpress server, bind() causes
 	 * Netty to bind to the listening address and process incoming messages.
@@ -642,19 +665,7 @@ public class RestExpress
 			bootstrap = Bootstraps.createServerNioBootstrap(getIoThreadCount());
 		}
 
-		// Set up the event pipeline factory.
-		DefaultRequestHandler requestHandler = new DefaultRequestHandler(
-		    createRouteResolver(), createResponseProcessorResolver());
-
-		// Add MessageObservers to the request handler here, if desired...
-		requestHandler.addMessageObserver(messageObservers.toArray(new MessageObserver[0]));
-
-		requestHandler.setExceptionMap(exceptionMap);
-
-		// Add pre/post processors to the request handler here...
-		addPreprocessors(requestHandler);
-		addPostprocessors(requestHandler);
-		addFinallyProcessors(requestHandler);
+        DefaultRequestHandler requestHandler = buildRequestHandler();
 
 		PipelineBuilder pf = new PipelineBuilder()
 		    .addRequestHandler(requestHandler)


### PR DESCRIPTION
So, I have an existing multi-protocol netty based engine that I'd like to throw a rest processor on top of. I just need to be able to add the request handler to my existing pipeline, but did not see how that could be done with the existing bind function. Here's my proposed patch, let me know if you're willing to accept it.

The "bind" function in RestExpress did not allow me to take the handler and add it to my own pipeline (outside of a system that traditionally holds it's own "main").
