### PR TITLE
Change query limit to accept 0 as a value, as per error message.

### DIFF
--- a/common/src/java/org/restexpress/common/query/QueryRange.java
+++ b/common/src/java/org/restexpress/common/query/QueryRange.java
@@ -123,7 +123,7 @@ implements Cloneable
 	 */
 	public void setLimit(int value)
 	{
-		if (value <= 0) throw new IllegalArgumentException("limit must be >= 0");
+		if (value < 0) throw new IllegalArgumentException("limit must be >= 0");
 
 		this.limit = Integer.valueOf(value);
 	}


### PR DESCRIPTION
Fix for this issue:
https://github.com/RestExpress/RestExpress/issues/73
