### PR TITLE
Added SSL support

### DIFF
--- a/core/src/java/org/restexpress/RestExpress.java
+++ b/core/src/java/org/restexpress/RestExpress.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.net.ssl.SSLContext;
+
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.group.ChannelGroup;
@@ -83,6 +85,7 @@ public class RestExpress
 	private ExceptionMapping exceptionMap = new DefaultExceptionMapper();
 	private List<Plugin> plugins = new ArrayList<Plugin>();
 	private RouteDeclaration routeDeclarations = new RouteDeclaration();
+	private SSLContext sslContext = null;
 	
 	/**
 	 * Change the default behavior for serialization.
@@ -139,6 +142,17 @@ public class RestExpress
 		useSystemOut();
 	}
 
+	public RestExpress setSSLContext(SSLContext sslContext)
+	{
+		this.sslContext = sslContext;
+		return this;
+	}
+	
+	public SSLContext getSSLContext()
+	{
+		return sslContext;
+	}
+	
 	public String getBaseUrl()
 	{
 		return routeDefaults.getBaseUrl();
@@ -526,6 +540,7 @@ public class RestExpress
 
 		PipelineBuilder pf = new PipelineBuilder()
 		    .addRequestHandler(requestHandler)
+		    .setSSLContext(sslContext)
 		    .setMaxContentLength(serverSettings.getMaxContentSize());
 
 		if (getExecutorThreadCount() > 0)

--- a/core/src/java/org/restexpress/util/SSLUtil.java
+++ b/core/src/java/org/restexpress/util/SSLUtil.java
@@ -1,0 +1,45 @@
+package org.restexpress.util;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+
+public class SSLUtil
+{
+	public static SSLContext loadContext(String keyStore,
+			String filePassword, String keyPassword) throws Exception
+	{
+		FileInputStream fin = null;
+
+		try
+		{
+			KeyStore ks = KeyStore.getInstance("JKS");
+			fin = new FileInputStream(keyStore);
+			ks.load(fin, filePassword.toCharArray());
+
+			KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+			kmf.init(ks, keyPassword.toCharArray());
+
+			SSLContext context = SSLContext.getInstance("TLS");
+			context.init(kmf.getKeyManagers(), null, null);
+			return context;
+		}
+		finally
+		{
+			if (null != fin)
+			{
+				try
+				{
+					fin.close();
+				}
+				catch (IOException e)
+				{
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
core/src/java/org/restexpress/RestExpress.java

RestExpress now accepts an SSLContext via setSSLContext.  If present, the SSLContext is passed along to the PipelineBuilder

core/src/java/org/restexpress/pipeline/PipelineBuilder.java

The PipelineBuilder now accepts an SSLContext.  If present when building a pipeline, the class uses the context to create an SSL Handler that it adds to the head of the pipeline.

core/src/java/org/restexpress/util/SSLUtil.java

Convenience class to load SSL certificates.
