### PR TITLE
Fix for returning 416 when offset is requested for an empty resultset

### DIFF
--- a/core/src/java/org/restexpress/Response.java
+++ b/core/src/java/org/restexpress/Response.java
@@ -171,7 +171,13 @@ public class Response
 		}
 		else if (range.extendsBeyond(size, count))
 		{
-			range.setLimitViaEnd((count > 1 ? count - 1 : 0));
+		    	if (count == 0 && range.getOffset() > 0) {
+		    	    setResponseCode(416);
+		    	    range.setOffset(0);
+		    	    range.setLimitViaEnd(0);
+		    	} else {
+		    	    range.setLimitViaEnd((count > 1 ? count - 1 : 0));
+		    	}
 			
 			if (count > 0 && !range.spans(size, count))
 			{

--- a/core/test/java/org/restexpress/ResponseTest.java
+++ b/core/test/java/org/restexpress/ResponseTest.java
@@ -98,6 +98,11 @@ public class ResponseTest
 		r.setCollectionResponse(new QueryRange(75l, 100), 0, 3);
 		assertEquals(416, r.getResponseStatus().code());
 		assertEquals("items 0-2/3", r.getHeader(HttpHeaders.Names.CONTENT_RANGE));
+		
+		r = new Response();
+		r.setCollectionResponse(new QueryRange(1l, 5), 0, 0);
+		assertEquals(416, r.getResponseStatus().code());
+		assertEquals("items 0-0/0", r.getHeader(HttpHeaders.Names.CONTENT_RANGE));
 	}
 
 	@Test


### PR DESCRIPTION
This fixes the following issue: If an offset greater than 0 is given when setting a collection response where the total number of results is 0, an IllegalArgumentException is thrown resulting in an incorrect 400 error response with the message "limit must be > 0". 
The change is to return a 416 unsatisfiable range response, with the content-range header set to 0-0/0. 