### PR TITLE
Use char[] instead of String within SslUtil

### DIFF
--- a/core/src/main/java/org/restexpress/util/SslUtil.java
+++ b/core/src/main/java/org/restexpress/util/SslUtil.java
@@ -10,7 +10,7 @@ import javax.net.ssl.SSLContext;
 public class SslUtil
 {
 	public static SSLContext loadContext(String keyStore,
-			String filePassword, String keyPassword) throws Exception
+			char[] filePassword, char[] keyPassword) throws Exception
 	{
 		FileInputStream fin = null;
 
@@ -18,10 +18,10 @@ public class SslUtil
 		{
 			KeyStore ks = KeyStore.getInstance("JKS");
 			fin = new FileInputStream(keyStore);
-			ks.load(fin, filePassword.toCharArray());
+			ks.load(fin, filePassword);
 
 			KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-			kmf.init(ks, keyPassword.toCharArray());
+			kmf.init(ks, keyPassword);
 
 			SSLContext context = SSLContext.getInstance("TLS");
 			context.init(kmf.getKeyManagers(), null, null);

--- a/core/src/main/java/org/restexpress/util/SslUtil.java
+++ b/core/src/main/java/org/restexpress/util/SslUtil.java
@@ -29,10 +29,7 @@ public class SslUtil
 			return context;
 		}
 		finally
-		{
-			//Arrays.fill(filePassword,'0');
-			//Arrays.fill(keyPassword,'0');
-			
+		{			
 			if (null != fin)
 			{
 				try

--- a/core/src/main/java/org/restexpress/util/SslUtil.java
+++ b/core/src/main/java/org/restexpress/util/SslUtil.java
@@ -1,5 +1,6 @@
 package org.restexpress.util;
 
+import java.util.Arrays;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
@@ -24,11 +25,14 @@ public class SslUtil
 			kmf.init(ks, keyPassword);
 
 			SSLContext context = SSLContext.getInstance("TLS");
-			context.init(kmf.getKeyManagers(), null, null);
+			context.init(kmf.getKeyManagers(), null, null);			
 			return context;
 		}
 		finally
 		{
+			//Arrays.fill(filePassword,'0');
+			//Arrays.fill(keyPassword,'0');
+			
 			if (null != fin)
 			{
 				try


### PR DESCRIPTION
In SslUtil the passwords are passed as Strings. Since it is not possible to overwrite or wipe out Strings because they are immutable, it is preferred to use char[] with sensible data.

Changed interface of SslUtil to use char[] instead of String for the passwords.