### PR TITLE
Update jackson-databind and xstream versions because of vulnerabilities

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,12 +27,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.7.4</version>
+			<version>2.8.11.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.9</version>
+			<version>1.4.10</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>


### PR DESCRIPTION
Force jackson-databind@2.8.11.1 to fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7489 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525.
Force use of xstream@1.4.9 to solve https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3674 and vulnerablility CVE-2017-7957. See http://x-stream.github.io/changes.html.